### PR TITLE
Add JWT authentication endpoints and permissions

### DIFF
--- a/accounts/permissions.py
+++ b/accounts/permissions.py
@@ -1,0 +1,15 @@
+from rest_framework.permissions import BasePermission
+
+class IsOrganizationMember(BasePermission):
+    """Allows access to users in the 'organization_member' group."""
+    def has_permission(self, request, view):
+        user = request.user
+        return bool(user and user.is_authenticated and user.groups.filter(name='organization_member').exists())
+
+class IsOrgAdmin(BasePermission):
+    """Allows access to organization admins."""
+    def has_permission(self, request, view):
+        user = request.user
+        return bool(user and user.is_authenticated and (
+            user.is_superuser or user.groups.filter(name='organization_admin').exists()
+        ))

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+from .views import LogoutView
+
+urlpatterns = [
+    path('login/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('logout/', LogoutView.as_view(), name='token_logout'),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,1 +1,19 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
 
+class LogoutView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        refresh = request.data.get('refresh')
+        if not refresh:
+            return Response({'detail': 'Refresh token required.'}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            token = RefreshToken(refresh)
+            token.blacklist()
+        except Exception:
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+        return Response(status=status.HTTP_205_RESET_CONTENT)

--- a/legal_ai/settings.py
+++ b/legal_ai/settings.py
@@ -15,6 +15,8 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
+    'rest_framework_simplejwt.token_blacklist',
     'accounts',
     'chat',
     'retrieval',
@@ -83,3 +85,13 @@ USE_TZ = True
 STATIC_URL = 'static/'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Django REST framework settings
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+}

--- a/legal_ai/urls.py
+++ b/legal_ai/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('auth/', include('accounts.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Django>=5.2,<5.3
+djangorestframework>=3.14
+djangorestframework-simplejwt>=5.3


### PR DESCRIPTION
## Summary
- setup Django REST Framework with JWT authentication
- add custom organization permissions
- implement login, refresh and logout endpoints
- include dependencies in requirements.txt

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_684005529edc832b9a93781ba7d9f9a8