### PR TITLE
Implement basic WebSocket chat

### DIFF
--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -1,0 +1,28 @@
+from channels.generic.websocket import AsyncWebsocketConsumer
+import json
+
+class ChatConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.session_id = self.scope['url_route']['kwargs']['session_id']
+        self.group_name = f"chat_{self.session_id}"
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(self.group_name, self.channel_name)
+
+    async def receive_json(self, content, **kwargs):
+        if content.get("type") == "user.message":
+            response = {
+                "type": "ai.message",
+                "content": f"Echo: {content.get('content', '')}",
+                "citations": [],
+                "message_id": content.get("tmp_id"),
+            }
+            await self.channel_layer.group_send(
+                self.group_name,
+                {"type": "chat.message", "message": response}
+            )
+
+    async def chat_message(self, event):
+        await self.send_json(event["message"])

--- a/chat/routing.py
+++ b/chat/routing.py
@@ -1,0 +1,6 @@
+from django.urls import re_path
+from .consumers import ChatConsumer
+
+websocket_urlpatterns = [
+    re_path(r'^ws/chat/(?P<session_id>[^/]+)/$', ChatConsumer.as_asgi()),
+]

--- a/legal_ai/asgi.py
+++ b/legal_ai/asgi.py
@@ -1,8 +1,18 @@
 """ASGI config for legal_ai project."""
 
 import os
+from channels.auth import AuthMiddlewareStack
+from channels.routing import ProtocolTypeRouter, URLRouter
 from django.core.asgi import get_asgi_application
+import chat.routing
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'legal_ai.settings')
 
-application = get_asgi_application()
+django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket": AuthMiddlewareStack(
+        URLRouter(chat.routing.websocket_urlpatterns)
+    ),
+})

--- a/legal_ai/settings.py
+++ b/legal_ai/settings.py
@@ -16,6 +16,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'channels',
     'rest_framework_simplejwt.token_blacklist',
     'accounts',
     'chat',
@@ -94,4 +95,15 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
+}
+
+# Channels settings
+ASGI_APPLICATION = 'legal_ai.asgi.application'
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels_redis.core.RedisChannelLayer',
+        'CONFIG': {
+            'hosts': [('localhost', 6379)],
+        },
+    },
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django>=5.2,<5.3
 djangorestframework>=3.14
 djangorestframework-simplejwt>=5.3
+channels==4
+channels-redis


### PR DESCRIPTION
## Summary
- add `channels` and `channels-redis` packages
- implement `ChatConsumer` and websocket routing
- configure Channels in ASGI and Django settings

## Testing
- `pip install -r requirements.txt`
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68400815d8ac832ba9addeb7608e56fc