### PR TITLE
Add LLM service

### DIFF
--- a/legal_ai/llm/__init__.py
+++ b/legal_ai/llm/__init__.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+from .client import get_llm_client, LLMClient
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+PROMPTS_DIR = BASE_DIR / "prompts"
+
+_env = Environment(loader=FileSystemLoader(str(PROMPTS_DIR)))
+
+
+def _extract_citations(text: str) -> list[str]:
+    """Extract citation ids from output text."""
+    return sorted(set(re.findall(r"\[(\d+)\]", text)))
+
+
+def generate_response(
+    question: str,
+    context: str = "",
+    client_kind: str = "openai",
+) -> tuple[str, list[str]]:
+    """Render prompt and get completion from chosen LLM.
+
+    Returns a tuple ``(text, cited_ids)``.
+    """
+    template = _env.get_template("base.jinja2")
+    prompt = template.render(question=question, context=context)
+
+    client: LLMClient = get_llm_client(client_kind)
+    text = client.generate(prompt)
+    cited_ids = _extract_citations(text)
+    return text, cited_ids

--- a/legal_ai/llm/client.py
+++ b/legal_ai/llm/client.py
@@ -1,0 +1,55 @@
+import os
+from typing import Protocol
+
+class LLMClient(Protocol):
+    """Simple protocol for LLM clients."""
+
+    def generate(self, prompt: str) -> str:
+        """Generate text from a prompt."""
+        raise NotImplementedError
+
+
+class OpenAIClient:
+    """Client for OpenAI's chat completion API."""
+
+    def __init__(self, api_key: str | None = None, model: str = "gpt-3.5-turbo"):
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.model = model
+
+    def generate(self, prompt: str) -> str:
+        try:
+            import openai
+        except ImportError as exc:
+            raise RuntimeError("openai package is required for OpenAIClient") from exc
+
+        openai.api_key = self.api_key
+        response = openai.ChatCompletion.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message["content"].strip()
+
+
+class LocalHFClient:
+    """Client that uses a local HuggingFace pipeline."""
+
+    def __init__(self, model: str = "distilgpt2"):
+        try:
+            from transformers import pipeline
+        except ImportError as exc:
+            raise RuntimeError("transformers package is required for LocalHFClient") from exc
+
+        self.generator = pipeline("text-generation", model=model)
+
+    def generate(self, prompt: str) -> str:
+        outputs = self.generator(prompt, max_length=256, num_return_sequences=1)
+        return outputs[0]["generated_text"].strip()
+
+
+def get_llm_client(kind: str = "openai") -> LLMClient:
+    """Factory that returns the desired LLM client."""
+    if kind == "openai":
+        return OpenAIClient()
+    if kind == "local":
+        return LocalHFClient()
+    raise ValueError(f"Unsupported LLM client: {kind}")

--- a/prompts/base.jinja2
+++ b/prompts/base.jinja2
@@ -1,0 +1,8 @@
+You are a helpful legal assistant.
+Context:
+{{ context }}
+
+User question:
+{{ question }}
+
+Provide a concise answer referencing sources as [1], [2], ... when relevant.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ djangorestframework>=3.14
 djangorestframework-simplejwt>=5.3
 channels==4
 channels-redis
+jinja2
+openai
+transformers


### PR DESCRIPTION
## Summary
- add LLM client factory with OpenAI and local HF options
- support Jinja2 prompts
- expose `generate_response` that returns generated text and citations
- include dependencies for Jinja2, OpenAI, and Transformers

## Testing
- `python -m py_compile legal_ai/llm/client.py legal_ai/llm/__init__.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68400a189024832ba47d4618fc6931a4