### PR TITLE
Implement retrieval pipeline

### DIFF
--- a/legal_ai/__init__.py
+++ b/legal_ai/__init__.py
@@ -1,0 +1,3 @@
+from .celery import app as celery_app
+
+__all__ = ('celery_app',)

--- a/legal_ai/celery.py
+++ b/legal_ai/celery.py
@@ -1,0 +1,8 @@
+import os
+from celery import Celery
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'legal_ai.settings')
+
+app = Celery('legal_ai')
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()

--- a/legal_ai/urls.py
+++ b/legal_ai/urls.py
@@ -4,4 +4,5 @@ from django.urls import path, include
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('auth/', include('accounts.urls')),
+    path('', include('retrieval.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,8 @@ channels-redis
 jinja2
 openai
 transformers
+celery
+pgvector
+pdfminer.six
+python-docx
+sentence-transformers

--- a/retrieval/models.py
+++ b/retrieval/models.py
@@ -1,1 +1,20 @@
+from django.db import models
+from django.contrib.postgres.search import SearchVectorField
+from pgvector.django import VectorField
+
+class LegalDocument(models.Model):
+    organization = models.ForeignKey('legalchat.Organization', on_delete=models.CASCADE, related_name='legal_documents')
+    file = models.FileField(upload_to='documents/')
+    uploaded_at = models.DateTimeField(auto_now_add=True)
+
+class LegalDocumentChunk(models.Model):
+    document = models.ForeignKey(LegalDocument, on_delete=models.CASCADE, related_name='chunks')
+    text = models.TextField()
+    embedding = VectorField(dimensions=768)
+    search_vector = SearchVectorField(null=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=['search_vector'], name='ld_chunk_search_vector_idx'),
+        ]
 

--- a/retrieval/tasks.py
+++ b/retrieval/tasks.py
@@ -1,0 +1,36 @@
+from celery import shared_task
+from .models import LegalDocument, LegalDocumentChunk
+from sentence_transformers import SentenceTransformer
+from django.contrib.postgres.search import SearchVector
+import pdfminer.high_level
+import docx
+
+model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')
+
+@shared_task
+def ingest_document(document_id: int) -> None:
+    doc = LegalDocument.objects.get(id=document_id)
+    text = _extract_text(doc.file.path)
+    chunks = list(_split_text(text, 1000))
+    embeddings = model.encode(chunks)
+    for chunk, emb in zip(chunks, embeddings):
+        LegalDocumentChunk.objects.create(
+            document=doc,
+            text=chunk,
+            embedding=emb.tolist(),
+            search_vector=SearchVector(chunk),
+        )
+
+def _extract_text(path: str) -> str:
+    if path.lower().endswith('.pdf'):
+        return pdfminer.high_level.extract_text(path)
+    if path.lower().endswith('.docx'):
+        document = docx.Document(path)
+        return '\n'.join(p.text for p in document.paragraphs)
+    with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+        return f.read()
+
+def _split_text(text: str, tokens: int):
+    words = text.split()
+    for i in range(0, len(words), tokens):
+        yield ' '.join(words[i:i+tokens])

--- a/retrieval/urls.py
+++ b/retrieval/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import SearchView
+
+urlpatterns = [
+    path('v1/search/', SearchView.as_view(), name='search'),
+]

--- a/retrieval/views.py
+++ b/retrieval/views.py
@@ -1,1 +1,23 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django.contrib.postgres.search import SearchVector, SearchQuery, SearchRank
+from pgvector.django import CosineDistance
+from .models import LegalDocumentChunk
+from sentence_transformers import SentenceTransformer
 
+model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')
+
+class SearchView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        query = request.query_params.get('q')
+        if not query:
+            return Response({'detail': 'Query parameter q required.'}, status=400)
+        embedding = model.encode([query])[0].tolist()
+        qs = (LegalDocumentChunk.objects
+              .annotate(rank=SearchRank(SearchVector('text'), SearchQuery(query)))
+              .order_by(CosineDistance('embedding', embedding))[:5])
+        results = [{'document_id': chunk.document_id, 'text': chunk.text} for chunk in qs]
+        return Response({'results': results})


### PR DESCRIPTION
## Summary
- add Celery setup for the project
- implement `LegalDocument` and `LegalDocumentChunk` models with pgvector
- create ingestion task to process documents and embed chunks
- expose search endpoint that uses embeddings with pgvector
- wire retrieval app URLs into project
- extend requirements with needed packages

## Testing
- `pip install -q -r requirements.txt`
- `python manage.py test` *(fails: Unable to download transformer model)*

------
https://chatgpt.com/codex/tasks/task_e_68400b988bec832b8694c51849c8df3c