### PR TITLE
Fix Django JSONField deprecation

### DIFF
--- a/backend/legal_ai/settings.py
+++ b/backend/legal_ai/settings.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = [
     "accounts",
     "chat",
     "retrieval",
+    "legalchat",
 ]
 
 MIDDLEWARE = [
@@ -70,7 +71,10 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        "NAME": (
+            "django.contrib.auth.password_validation."
+            "UserAttributeSimilarityValidator"
+        ),
     },
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",

--- a/backend/legalchat/apps.py
+++ b/backend/legalchat/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class LegalchatConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "legalchat"

--- a/backend/legalchat/models.py
+++ b/backend/legalchat/models.py
@@ -1,33 +1,46 @@
 from django.db import models
-from django.contrib.postgres.fields import JSONField
+from django.db.models import JSONField
+
 
 class Organization(models.Model):
     name = models.CharField(max_length=255)
 
+
 class User(models.Model):
-    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='users')
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="users"
+    )
     username = models.CharField(max_length=150, unique=True)
     email = models.EmailField(unique=True)
 
+
 class Role(models.TextChoices):
-    ADMIN = 'admin', 'Admin'
-    MEMBER = 'member', 'Member'
+    ADMIN = "admin", "Admin"
+    MEMBER = "member", "Member"
+
 
 class LegalDocument(models.Model):
-    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='documents')
-    file = models.FileField(upload_to='documents/')
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="documents"
+    )
+    file = models.FileField(upload_to="documents/")
     metadata = JSONField(blank=True, null=True)
     vector_embedding = models.BinaryField()
 
+
 class ChatSession(models.Model):
-    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, related_name='chat_sessions')
+    organization = models.ForeignKey(
+        Organization, on_delete=models.CASCADE, related_name="chat_sessions"
+    )
     created_at = models.DateTimeField(auto_now_add=True)
 
+
 class ChatMessage(models.Model):
-    session = models.ForeignKey(ChatSession, on_delete=models.CASCADE, related_name='messages')
+    session = models.ForeignKey(
+        ChatSession, on_delete=models.CASCADE, related_name="messages"
+    )
     user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True)
     message = models.TextField()
     embedding = models.BinaryField()
     citations = JSONField(blank=True, null=True)
     timestamp = models.DateTimeField(auto_now_add=True)
-


### PR DESCRIPTION
## Summary
- add legalchat AppConfig
- register legalchat in Django settings
- replace deprecated postgres JSONField usages

## Testing
- `pre-commit run --files backend/legalchat/models.py backend/legalchat/apps.py backend/legal_ai/settings.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684018199c0c832b903a96bd752927af