### PR TITLE
Add Celery worker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ This repository contains a Django backend and a Vite frontend.
 
 ## Local setup
 
+
 ```bash
 ./bootstrap.sh
 # then
 docker compose up --build
 ```
+
+This will start the backend, frontend, and the Celery worker for background tasks.
 
 The backend OpenAPI schema is available at `/schema/` and Swagger UI at `/docs/`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,5 @@ DJANGO_SECRET_KEY=replace-this-secret-key
 OPENAI_API_KEY=TODO
 DATABASE_URL=postgresql://legal_ai:legal_ai@db:5432/legal_ai
 REDIS_URL=redis://redis:6379/0
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/0

--- a/backend/legal_ai/settings.py
+++ b/backend/legal_ai/settings.py
@@ -124,3 +124,8 @@ CHANNEL_LAYERS = {
         },
     },
 }
+
+# Celery settings
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", os.getenv("REDIS_URL", "redis://localhost:6379/0"))
+CELERY_RESULT_BACKEND = os.getenv("CELERY_RESULT_BACKEND", CELERY_BROKER_URL)
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,21 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  celery:
+    build:
+      context: .
+      dockerfile: Dockerfile.back
+    command: celery -A legal_ai worker
+    env_file:
+      - backend/.env
+    environment:
+      - DATABASE_URL=postgresql://legal_ai:legal_ai@db:5432/legal_ai
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   frontend:
     build:
       context: .

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
 # Legal AI
 
 Welcome to the project documentation.
+
+To process background jobs, start the Celery worker along with other services:
+
+```bash
+docker compose up --build
+```


### PR DESCRIPTION
## Summary
- configure Celery broker and result backend
- add Celery worker service to compose stack
- document how to run the Celery worker

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840267f9524832bbe9ee5cbf51e9931